### PR TITLE
Better executor checking

### DIFF
--- a/scriptBeta.lua
+++ b/scriptBeta.lua
@@ -18,8 +18,21 @@ if islclosure(mt.__namecall) or islclosure(mt.__index) or islclosure(mt.__newind
     error("script incompatibility detected, one of your scripts has set the game's metamethods to a luaclosure, please run the remotespy prior to that script")
 end
 
-if not RenderWindow then
-    error("EXPLOIT NOT SUPPORTED - GET SYNAPSE V3")
+local execType, build = identifyexecutor()
+
+if execType == nil or build == nil then
+    error("THIS EXECUTOR IS NOT SUPPORTED")
+    return
+end
+
+if execType ~= "Synapse X" then
+    error("THIS EXECUTOR IS NOT SUPPORTED")
+    return
+end
+
+if string.split(build, "/")[1] ~= "v3" then
+    error("THIS EXECUTOR IS NOT SUPPORTED")
+    return
 end
 
 local function cleanUpSpy()

--- a/scriptBeta.lua
+++ b/scriptBeta.lua
@@ -18,21 +18,8 @@ if islclosure(mt.__namecall) or islclosure(mt.__index) or islclosure(mt.__newind
     error("script incompatibility detected, one of your scripts has set the game's metamethods to a luaclosure, please run the remotespy prior to that script")
 end
 
-local execType, build = identifyexecutor()
-
-if execType == nil or build == nil then
-    error("THIS EXECUTOR IS NOT SUPPORTED")
-    return
-end
-
-if execType ~= "Synapse X" then
-    error("THIS EXECUTOR IS NOT SUPPORTED")
-    return
-end
-
-if string.split(build, "/")[1] ~= "v3" then
-    error("THIS EXECUTOR IS NOT SUPPORTED")
-    return
+if not RenderWindow then
+    error("GET V3 BOZO")
 end
 
 local function cleanUpSpy()


### PR DESCRIPTION
Instead of checking for specific class, it uses the identifyexecutor() function to check if we are on synapse and on v3.